### PR TITLE
Enhance mobile country selector and add Egypt/Morocco regions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,36 +3,83 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jobbyist - Africa's Premier Job Discovery Platform | Jobs in South Africa & Nigeria</title>
-    <meta name="description" content="Discover thousands of job opportunities across South Africa and Nigeria. Africa's leading job platform connecting top talent with premier employers. Find your dream career today!">
-    <meta name="keywords" content="jobs in South Africa, jobs in Nigeria, job vacancies, employment opportunities, careers, recruitment, job search, South African jobs, Nigerian jobs, Johannesburg jobs, Lagos jobs, Cape Town jobs, Abuja jobs, African job board, remote jobs Africa">
+    <title>Jobbyist Africa Jobs | South Africa, Nigeria, Kenya, Ghana, Egypt & Morocco</title>
+    <meta name="description" content="Find jobs in South Africa, Nigeria, Kenya, Ghana, Egypt and Morocco with Jobbyist. Browse regional job opportunities, verified employers, resume tools and career resources across Africa.">
+    <meta name="keywords" content="jobs in South Africa, jobs in Nigeria, jobs in Kenya, jobs in Ghana, jobs in Egypt, jobs in Morocco, job vacancies Africa, employment opportunities, careers, recruitment, job search, African job board, remote jobs Africa, Johannesburg jobs, Lagos jobs, Nairobi jobs, Accra jobs, Cairo jobs, Casablanca jobs">
     <meta name="author" content="Jobbyist" />
     <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#0EA5E9" />
     <link rel="canonical" href="https://jobbyist.africa/" />
+    <link rel="alternate" href="https://jobbyist.africa/" hreflang="x-default" />
+    <link rel="alternate" href="https://za.jobbyist.africa/" hreflang="en-ZA" />
+    <link rel="alternate" href="https://ng.jobbyist.africa/" hreflang="en-NG" />
+    <link rel="alternate" href="https://ke.jobbyist.africa/" hreflang="en-KE" />
+    <link rel="alternate" href="https://gh.jobbyist.africa/" hreflang="en-GH" />
+    <link rel="alternate" href="https://eg.jobbyist.africa/" hreflang="en-EG" />
+    <link rel="alternate" href="https://ma.jobbyist.africa/" hreflang="en-MA" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://jobbyist.africa/" />
-    <meta property="og:title" content="Jobbyist - Africa's Premier Job Discovery Platform" />
-    <meta property="og:description" content="Discover thousands of job opportunities across South Africa and Nigeria. Find your dream career with Jobbyist." />
+    <meta property="og:title" content="Jobbyist Africa Jobs | Find Local Jobs Across Africa" />
+    <meta property="og:description" content="Discover jobs in South Africa, Nigeria, Kenya, Ghana, Egypt and Morocco. Choose your regional Jobbyist portal for tailored opportunities and career tools." />
     <meta property="og:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/676o3XGUnkNgBDw7vLNTBhgC4V13/social-images/social-1757843198296-jobbyist.jpg">
+    <meta property="og:site_name" content="Jobbyist" />
     <meta property="og:locale" content="en_ZA" />
     <meta property="og:locale:alternate" content="en_NG" />
+    <meta property="og:locale:alternate" content="en_KE" />
+    <meta property="og:locale:alternate" content="en_GH" />
+    <meta property="og:locale:alternate" content="en_EG" />
+    <meta property="og:locale:alternate" content="en_MA" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://jobbyist.africa/" />
-    <meta name="twitter:title" content="Jobbyist - Africa's Premier Job Discovery Platform" />
-    <meta name="twitter:description" content="Discover thousands of job opportunities across South Africa and Nigeria. Find your dream career with Jobbyist." />
+    <meta name="twitter:title" content="Jobbyist Africa Jobs | Find Local Jobs Across Africa" />
+    <meta name="twitter:description" content="Find jobs across South Africa, Nigeria, Kenya, Ghana, Egypt and Morocco with regional Jobbyist portals." />
     <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/676o3XGUnkNgBDw7vLNTBhgC4V13/social-images/social-1757843198296-jobbyist.jpg">
     <meta name="twitter:site" content="@jobbyist" />
-    
-    <!-- Geo tags for South Africa and Nigeria -->
+
+    <!-- Geo tags for regional search relevance -->
     <meta name="geo.region" content="ZA" />
     <meta name="geo.region" content="NG" />
-    <meta name="geo.placename" content="South Africa" />
-    <meta name="geo.placename" content="Nigeria" />
-    
+    <meta name="geo.region" content="KE" />
+    <meta name="geo.region" content="GH" />
+    <meta name="geo.region" content="EG" />
+    <meta name="geo.region" content="MA" />
+    <meta name="geo.placename" content="Africa" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Jobbyist",
+        "url": "https://jobbyist.africa/",
+        "description": "Africa's regional job discovery and career management platform.",
+        "inLanguage": "en",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://jobbyist.africa/jobs?search={search_term_string}",
+          "query-input": "required name=search_term_string"
+        },
+        "areaServed": ["South Africa", "Nigeria", "Kenya", "Ghana", "Egypt", "Morocco"]
+      }
+    </script>
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Jobbyist",
+        "url": "https://jobbyist.africa/",
+        "logo": "https://jobbyist.africa/jobbyist26.svg",
+        "sameAs": [
+          "https://facebook.com/JobbyistZA",
+          "https://linkedin.com/company/jobbyist"
+        ]
+      }
+    </script>
+
     <link rel="icon" type="image/x-icon" href="https://storage.googleapis.com/gpt-engineer-file-uploads/676o3XGUnkNgBDw7vLNTBhgC4V13/uploads/1757843205443-JOBBYIST (1).png">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1237323355260727"
      crossorigin="anonymous"></script>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Jobbyist - Africa's Premier Job Discovery Platform",
   "short_name": "Jobbyist",
-  "description": "Discover thousands of job opportunities across South Africa and Nigeria. Find your dream career with Jobbyist.",
+  "description": "Find jobs across South Africa, Nigeria, Kenya, Ghana, Egypt and Morocco with Jobbyist's regional job discovery and career tools.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,164 +3,267 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-  
-  <!-- Main Pages -->
+
+  <!-- Primary Jobbyist pages -->
   <url>
     <loc>https://jobbyist.africa/</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/jobs</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/pro</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/builder</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/companies</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
+  <!-- Regional portals -->
   <url>
-    <loc>https://jobbyist.africa/auth</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <loc>https://za.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
   </url>
-  
+
+  <url>
+    <loc>https://ng.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ke.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://gh.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://eg.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ma.jobbyist.africa/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
   <!-- Location-specific job pages - South Africa -->
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Johannesburg</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://za.jobbyist.africa/jobs?location=Johannesburg</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Cape%20Town</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://za.jobbyist.africa/jobs?location=Cape%20Town</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Durban</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://za.jobbyist.africa/jobs?location=Durban</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Pretoria</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://za.jobbyist.africa/jobs?location=Pretoria</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <!-- Location-specific job pages - Nigeria -->
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Lagos</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://ng.jobbyist.africa/jobs?location=Lagos</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Abuja</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://ng.jobbyist.africa/jobs?location=Abuja</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Port%20Harcourt</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://ng.jobbyist.africa/jobs?location=Port%20Harcourt</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
+  <!-- Location-specific job pages - Kenya -->
   <url>
-    <loc>https://jobbyist.africa/jobs?location=Ibadan</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://ke.jobbyist.africa/jobs?location=Nairobi</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ke.jobbyist.africa/jobs?location=Mombasa</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
+  <!-- Location-specific job pages - Ghana -->
+  <url>
+    <loc>https://gh.jobbyist.africa/jobs?location=Accra</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://gh.jobbyist.africa/jobs?location=Kumasi</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Location-specific job pages - Egypt -->
+  <url>
+    <loc>https://eg.jobbyist.africa/jobs?location=Cairo</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://eg.jobbyist.africa/jobs?location=Alexandria</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://eg.jobbyist.africa/jobs?location=Giza</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Location-specific job pages - Morocco -->
+  <url>
+    <loc>https://ma.jobbyist.africa/jobs?location=Casablanca</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ma.jobbyist.africa/jobs?location=Rabat</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ma.jobbyist.africa/jobs?location=Marrakesh</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
   <!-- Job Type pages -->
   <url>
     <loc>https://jobbyist.africa/jobs?type=full-time</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/jobs?type=part-time</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/jobs?type=contract</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/jobs?remote=true</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <!-- Legal Pages -->
   <url>
     <loc>https://jobbyist.africa/privacy-policy</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/terms-of-service</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/cookie-policy</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
   <url>
     <loc>https://jobbyist.africa/data-protection</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
 </urlset>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,33 +1,26 @@
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Briefcase, Facebook, Linkedin, Search, Moon, Sun, Smartphone } from 'lucide-react';
-import { useState } from 'react';
+import { Facebook, Linkedin, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import SearchModal from './SearchModal';
+import { SUPPORTED_COUNTRIES, getCountryUrl } from '@/utils/countryDetection';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
-  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const { theme, setTheme } = useTheme();
 
+  const regionLinks = SUPPORTED_COUNTRIES.filter((country) => country.code !== 'OTHER');
+
   const footerSections = {
-    locations: [
-      'South Africa',
-      'Nigeria', 
-      'Kenya',
-      'Ghana'
-    ],
     services: [
       'Upgrade To Pro',
       'Resume/CV Builder',
-      'Upskilling Programs'
+      'Upskilling Programs',
     ],
     legal: [
       'Privacy Policy',
       'Terms of Service',
       'Cookie Policy',
-      'Data Protection'
-    ]
+      'Data Protection',
+    ],
   };
 
   const socialLinks = [
@@ -43,12 +36,11 @@ const Footer = () => {
           <div className="lg:col-span-2">
             <div className="flex items-center gap-2 mb-4">
               <img src="/jobbyist26.svg" alt="Jobbyist Logo" style={{ width: '200px', height: 'auto' }} />
-             
             </div>
             <p className="text-muted-foreground mb-6 max-w-md">
-              Africa's leading job platform connecting top talent with premier employers across the continent.
+              Africa's leading job platform connecting top talent with premier employers across South Africa, Nigeria, Kenya, Ghana, Egypt, Morocco, and beyond.
             </p>
-            
+
             {/* Social Links */}
             <div className="flex gap-4 mb-6">
               {socialLinks.map((social) => {
@@ -61,9 +53,9 @@ const Footer = () => {
                     className="w-10 h-10 p-0"
                     asChild
                   >
-                    <a 
-                      href={social.href} 
-                      target="_blank" 
+                    <a
+                      href={social.href}
+                      target="_blank"
                       rel="noopener noreferrer"
                       aria-label={social.label}
                     >
@@ -79,11 +71,23 @@ const Footer = () => {
           <div>
             <h4 className="font-semibold text-foreground mb-4">Regions</h4>
             <ul className="space-y-2">
-              {footerSections.locations.map((item) => (
-                <li key={item}>
-                  <span className="text-muted-foreground">
-                    {item}
-                  </span>
+              {regionLinks.map((country) => (
+                <li key={country.code}>
+                  <a
+                    href={getCountryUrl(country.code)}
+                    className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label={`Visit Jobbyist ${country.name}`}
+                  >
+                    {country.flagSrc && (
+                      <img
+                        src={country.flagSrc}
+                        alt=""
+                        loading="lazy"
+                        className="h-4 w-6 rounded-sm object-cover ring-1 ring-border"
+                      />
+                    )}
+                    <span>{country.name}</span>
+                  </a>
                 </li>
               ))}
             </ul>
@@ -153,11 +157,11 @@ const Footer = () => {
                 Stay connected with job opportunities on the go
               </p>
             </div>
-            
+
             <div className="flex flex-col sm:flex-row gap-4">
               {/* App Store Badge */}
-              <a 
-                href="#" 
+              <a
+                href="#"
                 className="inline-flex items-center gap-3 bg-black dark:bg-white text-white dark:text-black px-6 py-3 rounded-lg hover:opacity-80 transition-opacity"
                 aria-label="Download on the App Store"
               >
@@ -173,8 +177,8 @@ const Footer = () => {
               </a>
 
               {/* Google Play Badge */}
-              <a 
-                href="#" 
+              <a
+                href="#"
                 className="inline-flex items-center gap-3 bg-black dark:bg-white text-white dark:text-black px-6 py-3 rounded-lg hover:opacity-80 transition-opacity"
                 aria-label="Get it on Google Play"
               >
@@ -202,7 +206,7 @@ const Footer = () => {
               Made with ❤️ for African job seekers
             </p>
           </div>
-          
+
           {/* Theme Toggle */}
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">Theme:</span>
@@ -219,11 +223,6 @@ const Footer = () => {
           </div>
         </div>
       </div>
-      
-      <SearchModal 
-        open={isSearchModalOpen} 
-        onOpenChange={setIsSearchModalOpen} 
-      />
     </footer>
   );
 };

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -25,7 +25,7 @@ interface OnboardingModalProps {
 type OnboardingStep = 1 | 2 | 3 | 4;
 
 const EXPERIENCE_LEVELS = ['entry', 'junior', 'mid', 'senior', 'executive'] as const;
-const COUNTRIES = ['South Africa', 'Nigeria', 'Kenya', 'Ghana', 'Other'];
+const COUNTRIES = ['South Africa', 'Nigeria', 'Kenya', 'Ghana', 'Egypt', 'Morocco', 'Other'];
 
 export const OnboardingModal = ({ open, onOpenChange, userId }: OnboardingModalProps) => {
   const [step, setStep] = useState<OnboardingStep>(1);
@@ -195,7 +195,7 @@ export const OnboardingModal = ({ open, onOpenChange, userId }: OnboardingModalP
                 <Input
                   id="location"
                   type="text"
-                  placeholder="e.g., Johannesburg, Lagos, Nairobi"
+                  placeholder="e.g., Johannesburg, Lagos, Cairo"
                   value={formData.location}
                   onChange={(e) => setFormData(prev => ({ ...prev, location: e.target.value }))}
                   className="text-lg py-6"

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -4,12 +4,37 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { MapPin, ArrowRight, Globe } from 'lucide-react';
 import Footer from '@/components/Footer';
-import { 
-  SUPPORTED_COUNTRIES, 
-  detectUserCountry, 
+import {
+  SUPPORTED_COUNTRIES,
+  detectUserCountry,
+  getCountryUrl,
   redirectToCountrySubdomain,
-  type CountryInfo 
+  type CountryInfo,
 } from '@/utils/countryDetection';
+
+interface CountryFlagProps {
+  country: CountryInfo;
+  className?: string;
+}
+
+const CountryFlag = ({ country, className = 'h-16 w-24' }: CountryFlagProps) => {
+  if (!country.flagSrc) {
+    return (
+      <div className={`${className} flex items-center justify-center rounded-2xl bg-primary/10 text-primary ring-1 ring-border`}>
+        <Globe className="h-8 w-8" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={country.flagSrc}
+      alt={`${country.name} flag`}
+      loading="lazy"
+      className={`${className} rounded-2xl object-cover shadow-sm ring-1 ring-border bg-background`}
+    />
+  );
+};
 
 const LandingPage = () => {
   const [detectedCountry, setDetectedCountry] = useState<CountryInfo | null>(null);
@@ -24,6 +49,11 @@ const LandingPage = () => {
   const handleCountrySelect = (countryCode: string) => {
     setIsRedirecting(true);
     redirectToCountrySubdomain(countryCode);
+  };
+
+  const handleCountryLinkClick = (event: React.MouseEvent<HTMLAnchorElement>, countryCode: string) => {
+    event.preventDefault();
+    handleCountrySelect(countryCode);
   };
 
   const handleAutoRedirect = () => {
@@ -46,37 +76,41 @@ const LandingPage = () => {
       </header>
 
       {/* Hero Section */}
-      <section className="py-16 md:py-24 px-4">
-        <div className="container mx-auto text-center max-w-4xl">
+      <section className="py-14 md:py-24 px-4">
+        <div className="container mx-auto text-center max-w-5xl">
           <Badge variant="secondary" className="mb-6 text-base px-4 py-2">
             <Globe className="h-4 w-4 mr-2" />
             Select Your Region
           </Badge>
-          
+
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-6 leading-tight">
             Welcome to Jobbyist
           </h1>
-          
-          <p className="text-lg md:text-xl text-muted-foreground mb-10 max-w-2xl mx-auto leading-relaxed">
-            Africa's Premier Job Discovery & Career Management Platform. 
-            Select your country/region to access job opportunities tailored to your region.
+
+          <p className="text-lg md:text-xl text-muted-foreground mb-10 max-w-3xl mx-auto leading-relaxed">
+            Africa's Premier Job Discovery & Career Management Platform. Select your country or region to access job opportunities tailored to your market.
           </p>
 
           {/* Auto-detected Country Card */}
           {detectedCountry && detectedCountry.code !== 'OTHER' && (
-            <Card className="mb-12 p-6 max-w-md mx-auto border-2 border-primary/20 bg-primary/5">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <span className="text-4xl">{detectedCountry.flag}</span>
-                  <div className="text-left">
-                    <p className="text-sm text-muted-foreground">We detected you're in</p>
-                    <p className="font-semibold text-lg">{detectedCountry.name}</p>
+            <Card className="mb-12 max-w-xl mx-auto border-2 border-primary/20 bg-primary/5 p-5 shadow-lg shadow-primary/5 sm:p-6">
+              <div className="flex flex-col items-center gap-5 text-center sm:flex-row sm:justify-between sm:text-left">
+                <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center">
+                  <CountryFlag country={detectedCountry} className="h-20 w-28 sm:h-16 sm:w-24" />
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      We detected you're in {detectedCountry.name}
+                    </p>
+                    <p className="font-semibold text-lg text-foreground">
+                      Continue to {detectedCountry.subdomain}
+                    </p>
                   </div>
                 </div>
-                <Button 
+                <Button
                   onClick={handleAutoRedirect}
                   disabled={isRedirecting}
                   size="lg"
+                  className="w-full sm:w-auto"
                 >
                   {isRedirecting ? 'Redirecting...' : 'Continue'}
                   <ArrowRight className="ml-2 h-4 w-4" />
@@ -87,49 +121,56 @@ const LandingPage = () => {
 
           {/* Country Selection Grid */}
           <div className="mb-8">
-            <h2 className="text-2xl font-bold text-foreground mb-6">
+            <h2 className="text-2xl font-bold text-foreground mb-3">
               Or Select Your Country
             </h2>
-            
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl mx-auto">
-              {SUPPORTED_COUNTRIES.filter(c => c.code !== 'OTHER').map((country) => (
-                <Card
+            <p className="text-muted-foreground mb-6">
+              Choose a dedicated regional portal for local jobs, employers, and career tools.
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-6xl mx-auto">
+              {SUPPORTED_COUNTRIES.filter((country) => country.code !== 'OTHER').map((country) => (
+                <a
                   key={country.code}
-                  className="p-6 hover:shadow-lg transition-all cursor-pointer hover:border-primary/50 group"
-                  onClick={() => handleCountrySelect(country.code)}
+                  href={getCountryUrl(country.code)}
+                  onClick={(event) => handleCountryLinkClick(event, country.code)}
+                  className="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-2xl"
+                  aria-label={`Visit Jobbyist ${country.name} at ${country.subdomain}`}
                 >
-                  <div className="flex flex-col items-center gap-3">
-                    <span className="text-5xl group-hover:scale-110 transition-transform">
-                      {country.flag}
-                    </span>
-                    <h3 className="font-semibold text-lg">{country.name}</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {country.subdomain}
-                    </p>
-                    <Button 
-                      variant="outline" 
-                      size="sm"
-                      disabled={isRedirecting}
-                      className="w-full mt-2"
-                    >
-                      Visit Site
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </Button>
-                  </div>
-                </Card>
+                  <Card className="h-full p-6 hover:shadow-xl transition-all hover:-translate-y-1 hover:border-primary/50 bg-background/90">
+                    <div className="flex flex-col items-center gap-4">
+                      <CountryFlag
+                        country={country}
+                        className="h-20 w-28 transition-transform group-hover:scale-105"
+                      />
+                      <div>
+                        <h3 className="font-semibold text-lg text-foreground">{country.name}</h3>
+                        <p className="text-sm text-muted-foreground">
+                          {country.subdomain}
+                        </p>
+                      </div>
+                      <span className="inline-flex w-full items-center justify-center rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors group-hover:bg-accent group-hover:text-accent-foreground">
+                        Visit Site
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </span>
+                    </div>
+                  </Card>
+                </a>
               ))}
             </div>
           </div>
 
           {/* Other Countries Option */}
-          <Card className="p-6 max-w-md mx-auto border border-dashed">
+          <Card className="p-6 max-w-md mx-auto border border-dashed bg-background/80">
             <div className="flex flex-col items-center gap-3">
-              <span className="text-4xl">🌍</span>
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Globe className="h-8 w-8" aria-hidden="true" />
+              </div>
               <h3 className="font-semibold text-lg">Other Countries</h3>
               <p className="text-sm text-muted-foreground text-center">
                 Looking for opportunities across all of Africa?
               </p>
-              <Button 
+              <Button
                 variant="outline"
                 onClick={() => handleCountrySelect('OTHER')}
                 disabled={isRedirecting}
@@ -150,7 +191,7 @@ const LandingPage = () => {
             <h2 className="text-3xl font-bold text-center mb-12">
               Why Choose Jobbyist?
             </h2>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               <div className="text-center">
                 <div className="bg-primary/10 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">

--- a/src/utils/countryDetection.ts
+++ b/src/utils/countryDetection.ts
@@ -1,87 +1,125 @@
+import southAfricaFlag from '../../regions/southafrica.svg';
+import nigeriaFlag from '../../regions/nigeria.svg';
+import kenyaFlag from '../../regions/kenya.svg';
+import ghanaFlag from '../../regions/ghana.svg';
+import egyptFlag from '../../regions/egypt.svg';
+import moroccoFlag from '../../regions/morocco.svg';
+
 // Country detection and subdomain mapping
 export interface CountryInfo {
   code: string;
   name: string;
   subdomain: string;
-  flag: string;
+  flagSrc?: string;
 }
+
+const OTHER_COUNTRY_CODE = 'OTHER';
 
 export const SUPPORTED_COUNTRIES: CountryInfo[] = [
   {
     code: 'ZA',
     name: 'South Africa',
     subdomain: 'za.jobbyist.africa',
-    flag: '🇿🇦'
+    flagSrc: southAfricaFlag,
   },
   {
     code: 'NG',
     name: 'Nigeria',
     subdomain: 'ng.jobbyist.africa',
-    flag: '🇳🇬'
+    flagSrc: nigeriaFlag,
   },
   {
     code: 'KE',
     name: 'Kenya',
     subdomain: 'ke.jobbyist.africa',
-    flag: '🇰🇪'
+    flagSrc: kenyaFlag,
   },
   {
     code: 'GH',
     name: 'Ghana',
     subdomain: 'gh.jobbyist.africa',
-    flag: '🇬🇭'
+    flagSrc: ghanaFlag,
   },
   {
-    code: 'OTHER',
+    code: 'EG',
+    name: 'Egypt',
+    subdomain: 'eg.jobbyist.africa',
+    flagSrc: egyptFlag,
+  },
+  {
+    code: 'MA',
+    name: 'Morocco',
+    subdomain: 'ma.jobbyist.africa',
+    flagSrc: moroccoFlag,
+  },
+  {
+    code: OTHER_COUNTRY_CODE,
     name: 'Other Countries',
     subdomain: 'www.jobbyist.africa',
-    flag: '🌍'
-  }
+  },
 ];
 
+const TIMEZONE_COUNTRY_MAP: Record<string, string> = {
+  'Africa/Johannesburg': 'ZA',
+  'Africa/Lagos': 'NG',
+  'Africa/Nairobi': 'KE',
+  'Africa/Accra': 'GH',
+  'Africa/Cairo': 'EG',
+  'Africa/Casablanca': 'MA',
+};
+
+const getCountryByCode = (countryCode: string): CountryInfo | undefined =>
+  SUPPORTED_COUNTRIES.find((country) => country.code === countryCode);
+
+const getOtherCountry = (): CountryInfo => getCountryByCode(OTHER_COUNTRY_CODE)!;
+
+const getLocaleCountryCodes = (): string[] => {
+  const locales = [navigator.language, ...(navigator.languages ?? [])].filter(Boolean);
+
+  return locales
+    .map((locale) => locale.split(/[-_]/)[1]?.toUpperCase())
+    .filter((countryCode): countryCode is string => Boolean(countryCode));
+};
+
 /**
- * Detects user's country based on browser locale and timezone
- * This is a client-side detection and should be supplemented with IP-based detection in production
+ * Detects user's country based on browser locale and timezone.
+ * This is client-side detection and should be supplemented with IP-based detection in production.
  */
 export const detectUserCountry = (): CountryInfo => {
   try {
-    // Try to detect from browser locale
-    const locale = navigator.language || 'en-US';
-    const countryCode = locale.split('-')[1]?.toUpperCase();
-    
-    // Check if detected country is in our supported list
-    const country = SUPPORTED_COUNTRIES.find(c => c.code === countryCode);
-    if (country) {
-      return country;
-    }
-    
-    // Try timezone-based detection as fallback
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if (timezone.includes('Africa/Johannesburg') || timezone.includes('Africa/Lagos')) {
-      if (timezone.includes('Johannesburg')) {
-        return SUPPORTED_COUNTRIES.find(c => c.code === 'ZA')!;
+    // Try to detect from browser locale first.
+    for (const countryCode of getLocaleCountryCodes()) {
+      const country = getCountryByCode(countryCode);
+      if (country && country.code !== OTHER_COUNTRY_CODE) {
+        return country;
       }
-      return SUPPORTED_COUNTRIES.find(c => c.code === 'NG')!;
     }
-    
-    // Default to "Other Countries"
-    return SUPPORTED_COUNTRIES.find(c => c.code === 'OTHER')!;
+
+    // Try timezone-based detection as fallback.
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const timezoneCountryCode = TIMEZONE_COUNTRY_MAP[timezone];
+    if (timezoneCountryCode) {
+      return getCountryByCode(timezoneCountryCode) ?? getOtherCountry();
+    }
+
+    // Default to "Other Countries".
+    return getOtherCountry();
   } catch (error) {
     console.error('Error detecting country:', error);
-    return SUPPORTED_COUNTRIES.find(c => c.code === 'OTHER')!;
+    return getOtherCountry();
   }
 };
 
 /**
- * Gets the full URL for a country subdomain
+ * Gets the full URL for a country subdomain.
  */
 export const getCountryUrl = (countryCode: string): string => {
-  const country = SUPPORTED_COUNTRIES.find(c => c.code === countryCode);
+  const country = getCountryByCode(countryCode);
   return country ? `https://${country.subdomain}` : 'https://www.jobbyist.africa';
 };
 
 /**
- * Redirects user to their country-specific subdomain
+ * Redirects user to their country-specific subdomain.
  */
 export const redirectToCountrySubdomain = (countryCode: string): void => {
   const url = getCountryUrl(countryCode);


### PR DESCRIPTION
## Summary
- Reworked the landing page country selector for mobile with SVG flag assets from `/regions` instead of emoji flags.
- Added Egypt and Morocco to supported country data, detection fallbacks, regional links, and onboarding country options.
- Updated footer region links to include all supported regional portals with flag icons.
- Expanded SEO metadata, hreflang alternates, structured data, manifest copy, and sitemap coverage for the expanded regional set.

## Notes
- Egypt links to `https://eg.jobbyist.africa`.
- Morocco links to `https://ma.jobbyist.africa`.
- The detected-country card places the flag above the detection text on mobile and uses SVG images for broad device support.

## Validation
- Reviewed branch diff against `main` and confirmed changes are limited to the selector, region data, footer, onboarding country options, and SEO/static metadata files.